### PR TITLE
`pip_compile_opts`, `--pip-compile-opts` and `PIP_COMPILE_OPTS`

### DIFF
--- a/examples/env-pins/requirements/py27.txt
+++ b/examples/env-pins/requirements/py27.txt
@@ -4,54 +4,102 @@
 #
 #    tox -e py27 --recreate --pip-compile
 #
-atomicwrites==1.4.1
+atomicwrites==1.4.1 \
+    --hash=sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11
     # via pytest
-attrs==21.4.0
+attrs==21.4.0 \
+    --hash=sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4 \
+    --hash=sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd
     # via
-    #   -r /var/folders/5z/zrfn8mrs2yj5cckpwyry7btm0000gn/T/tmpmzbagiup
+    #   -r /Users/masen/code/tox-dev/tox-pin-deps/examples/env-pins/.tox-pin-deps-py27-requirements.jodfmjq1.in
     #   pytest
-backports.functools-lru-cache==1.6.4
+backports.functools-lru-cache==1.6.4 \
+    --hash=sha256:d5ed2169378b67d3c545e5600d363a923b09c456dab1593914935a68ad478271 \
+    --hash=sha256:dbead04b9daa817909ec64e8d2855fb78feafe0b901d4568758e3a60559d8978
     # via wcwidth
-configparser==4.0.2
+configparser==4.0.2 \
+    --hash=sha256:254c1d9c79f60c45dfde850850883d5aaa7f19a23f13561243a050d5a7c3fe4c \
+    --hash=sha256:c7d282687a5308319bf3d2e7706e575c635b0a470342641c93bea0ea3b5331df
     # via importlib-metadata
-contextlib2==0.6.0.post1
+contextlib2==0.6.0.post1 \
+    --hash=sha256:01f490098c18b19d2bd5bb5dc445b2054d2fa97f09a4280ba2c5f3c394c8162e \
+    --hash=sha256:3355078a159fbb44ee60ea80abd0d87b80b78c248643b49aa6d94673b413609b
     # via importlib-metadata
-funcsigs==1.0.2
+funcsigs==1.0.2 \
+    --hash=sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca \
+    --hash=sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50
     # via pytest
-importlib-metadata==2.1.3
+importlib-metadata==2.1.3 \
+    --hash=sha256:02a9f62b02e9b1cc43871809ef99947e8f5d94771392d666ada2cafc4cd09d4f \
+    --hash=sha256:52e65a0856f9ba7ea8f2c4ced253fb6c88d1a8c352cb1e916cff4eb17d5a693d
     # via
     #   pluggy
     #   pytest
-more-itertools==5.0.0
+more-itertools==5.0.0 \
+    --hash=sha256:38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4 \
+    --hash=sha256:c0a5785b1109a6bd7fac76d6837fd1feca158e54e521ccd2ae8bfe393cc9d4fc \
+    --hash=sha256:fe7a7cae1ccb57d33952113ff4fa1bc5f879963600ed74918f1236e212ee50b9
     # via pytest
-packaging==20.9
+packaging==20.9 \
+    --hash=sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5 \
+    --hash=sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a
     # via
-    #   -r /var/folders/5z/zrfn8mrs2yj5cckpwyry7btm0000gn/T/tmpmzbagiup
+    #   -r /Users/masen/code/tox-dev/tox-pin-deps/examples/env-pins/.tox-pin-deps-py27-requirements.jodfmjq1.in
     #   pytest
-pathlib2==2.3.7.post1
+pathlib2==2.3.7.post1 \
+    --hash=sha256:5266a0fd000452f1b3467d782f079a4343c63aaa119221fbdc4e39577489ca5b \
+    --hash=sha256:9fe0edad898b83c0c3e199c842b27ed216645d2e177757b2dd67384d4113c641
     # via
     #   importlib-metadata
     #   pytest
-pluggy==0.13.1
+pluggy==0.13.1 \
+    --hash=sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0 \
+    --hash=sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d
     # via pytest
-py==1.11.0
+py==1.11.0 \
+    --hash=sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719 \
+    --hash=sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378
     # via pytest
-pyparsing==2.4.7
+pyparsing==2.4.7 \
+    --hash=sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1 \
+    --hash=sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b
     # via
-    #   -r /var/folders/5z/zrfn8mrs2yj5cckpwyry7btm0000gn/T/tmpmzbagiup
+    #   -r /Users/masen/code/tox-dev/tox-pin-deps/examples/env-pins/.tox-pin-deps-py27-requirements.jodfmjq1.in
     #   packaging
-pytest==4.6.11
-    # via -r /var/folders/5z/zrfn8mrs2yj5cckpwyry7btm0000gn/T/tmpmzbagiup
-scandir==1.10.0
+pytest==4.6.11 \
+    --hash=sha256:50fa82392f2120cc3ec2ca0a75ee615be4c479e66669789771f1758332be4353 \
+    --hash=sha256:a00a7d79cbbdfa9d21e7d0298392a8dd4123316bfac545075e6f8f24c94d8c97
+    # via -r /Users/masen/code/tox-dev/tox-pin-deps/examples/env-pins/.tox-pin-deps-py27-requirements.jodfmjq1.in
+scandir==1.10.0 \
+    --hash=sha256:2586c94e907d99617887daed6c1d102b5ca28f1085f90446554abf1faf73123e \
+    --hash=sha256:2ae41f43797ca0c11591c0c35f2f5875fa99f8797cb1a1fd440497ec0ae4b022 \
+    --hash=sha256:2b8e3888b11abb2217a32af0766bc06b65cc4a928d8727828ee68af5a967fa6f \
+    --hash=sha256:2c712840c2e2ee8dfaf36034080108d30060d759c7b73a01a52251cc8989f11f \
+    --hash=sha256:4d4631f6062e658e9007ab3149a9b914f3548cb38bfb021c64f39a025ce578ae \
+    --hash=sha256:67f15b6f83e6507fdc6fca22fedf6ef8b334b399ca27c6b568cbfaa82a364173 \
+    --hash=sha256:7d2d7a06a252764061a020407b997dd036f7bd6a175a5ba2b345f0a357f0b3f4 \
+    --hash=sha256:8c5922863e44ffc00c5c693190648daa6d15e7c1207ed02d6f46a8dcc2869d32 \
+    --hash=sha256:92c85ac42f41ffdc35b6da57ed991575bdbe69db895507af88b9f499b701c188 \
+    --hash=sha256:b24086f2375c4a094a6b51e78b4cf7ca16c721dcee2eddd7aa6494b42d6d519d \
+    --hash=sha256:cb925555f43060a1745d0a321cca94bcea927c50114b623d73179189a4e100ac
     # via pathlib2
-six==1.16.0
+six==1.16.0 \
+    --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
+    --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
     # via
     #   more-itertools
     #   pathlib2
     #   pytest
-typing==3.10.0.0
+typing==3.10.0.0 \
+    --hash=sha256:12fbdfbe7d6cca1a42e485229afcb0b0c8259258cfb919b8a5e2a5c953742f89 \
+    --hash=sha256:13b4ad211f54ddbf93e5901a9967b1e07720c1d1b78d596ac6a439641aa1b130 \
+    --hash=sha256:c7219ef20c5fbf413b4567092adfc46fa6203cb8454eda33c3fc1afe1398a308
     # via pathlib2
-wcwidth==0.2.5
+wcwidth==0.2.5 \
+    --hash=sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784 \
+    --hash=sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83
     # via pytest
-zipp==1.2.0
+zipp==1.2.0 \
+    --hash=sha256:c70410551488251b0fee67b460fb9a536af8d6f9f008ad10ac51f615b6a521b1 \
+    --hash=sha256:e0d9e63797e483a30d27e09fffd308c59a700d365ec34e93cc100844168bf921
     # via importlib-metadata

--- a/examples/env-pins/requirements/py310.txt
+++ b/examples/env-pins/requirements/py310.txt
@@ -4,27 +4,77 @@
 #
 #    tox -e py310 --recreate --pip-compile
 #
-attrs==22.1.0
+attrs==22.1.0 \
+    --hash=sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6 \
+    --hash=sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c
     # via pytest
-exceptiongroup==1.0.4
+exceptiongroup==1.0.4 \
+    --hash=sha256:542adf9dea4055530d6e1279602fa5cb11dab2395fa650b8674eaec35fc4a828 \
+    --hash=sha256:bd14967b79cd9bdb54d97323216f8fdf533e278df937aa2a90089e7d6e06e5ec
     # via pytest
-iniconfig==1.1.1
+iniconfig==1.1.1 \
+    --hash=sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3 \
+    --hash=sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32
     # via pytest
-mypy==0.991
-    # via -r /var/folders/5z/zrfn8mrs2yj5cckpwyry7btm0000gn/T/tmpjh9hcten
-mypy-extensions==0.4.3
+mypy==0.991 \
+    --hash=sha256:0714258640194d75677e86c786e80ccf294972cc76885d3ebbb560f11db0003d \
+    --hash=sha256:0c8f3be99e8a8bd403caa8c03be619544bc2c77a7093685dcf308c6b109426c6 \
+    --hash=sha256:0cca5adf694af539aeaa6ac633a7afe9bbd760df9d31be55ab780b77ab5ae8bf \
+    --hash=sha256:1c8cd4fb70e8584ca1ed5805cbc7c017a3d1a29fb450621089ffed3e99d1857f \
+    --hash=sha256:1f7d1a520373e2272b10796c3ff721ea1a0712288cafaa95931e66aa15798813 \
+    --hash=sha256:209ee89fbb0deed518605edddd234af80506aec932ad28d73c08f1400ef80a33 \
+    --hash=sha256:26efb2fcc6b67e4d5a55561f39176821d2adf88f2745ddc72751b7890f3194ad \
+    --hash=sha256:37bd02ebf9d10e05b00d71302d2c2e6ca333e6c2a8584a98c00e038db8121f05 \
+    --hash=sha256:3a700330b567114b673cf8ee7388e949f843b356a73b5ab22dd7cff4742a5297 \
+    --hash=sha256:3c0165ba8f354a6d9881809ef29f1a9318a236a6d81c690094c5df32107bde06 \
+    --hash=sha256:3d80e36b7d7a9259b740be6d8d906221789b0d836201af4234093cae89ced0cd \
+    --hash=sha256:4175593dc25d9da12f7de8de873a33f9b2b8bdb4e827a7cae952e5b1a342e243 \
+    --hash=sha256:4307270436fd7694b41f913eb09210faff27ea4979ecbcd849e57d2da2f65305 \
+    --hash=sha256:5e80e758243b97b618cdf22004beb09e8a2de1af481382e4d84bc52152d1c476 \
+    --hash=sha256:641411733b127c3e0dab94c45af15fea99e4468f99ac88b39efb1ad677da5711 \
+    --hash=sha256:652b651d42f155033a1967739788c436491b577b6a44e4c39fb340d0ee7f0d70 \
+    --hash=sha256:6d7464bac72a85cb3491c7e92b5b62f3dcccb8af26826257760a552a5e244aa5 \
+    --hash=sha256:74e259b5c19f70d35fcc1ad3d56499065c601dfe94ff67ae48b85596b9ec1461 \
+    --hash=sha256:7d17e0a9707d0772f4a7b878f04b4fd11f6f5bcb9b3813975a9b13c9332153ab \
+    --hash=sha256:901c2c269c616e6cb0998b33d4adbb4a6af0ac4ce5cd078afd7bc95830e62c1c \
+    --hash=sha256:98e781cd35c0acf33eb0295e8b9c55cdbef64fcb35f6d3aa2186f289bed6e80d \
+    --hash=sha256:a12c56bf73cdab116df96e4ff39610b92a348cc99a1307e1da3c3768bbb5b135 \
+    --hash=sha256:ac6e503823143464538efda0e8e356d871557ef60ccd38f8824a4257acc18d93 \
+    --hash=sha256:b8472f736a5bfb159a5e36740847808f6f5b659960115ff29c7cecec1741c648 \
+    --hash=sha256:b86ce2c1866a748c0f6faca5232059f881cda6dda2a893b9a8373353cfe3715a \
+    --hash=sha256:bc9ec663ed6c8f15f4ae9d3c04c989b744436c16d26580eaa760ae9dd5d662eb \
+    --hash=sha256:c9166b3f81a10cdf9b49f2d594b21b31adadb3d5e9db9b834866c3258b695be3 \
+    --hash=sha256:d13674f3fb73805ba0c45eb6c0c3053d218aa1f7abead6e446d474529aafc372 \
+    --hash=sha256:de32edc9b0a7e67c2775e574cb061a537660e51210fbf6006b0b36ea695ae9bb \
+    --hash=sha256:e62ebaad93be3ad1a828a11e90f0e76f15449371ffeecca4a0a0b9adc99abcef
+    # via -r /Users/masen/code/tox-dev/tox-pin-deps/examples/env-pins/.tox-pin-deps-py310-requirements.p587t3zp.in
+mypy-extensions==0.4.3 \
+    --hash=sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d \
+    --hash=sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8
     # via mypy
-packaging==21.3
+packaging==21.3 \
+    --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
+    --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
     # via pytest
-pluggy==1.0.0
+pluggy==1.0.0 \
+    --hash=sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159 \
+    --hash=sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3
     # via pytest
-pyparsing==3.0.9
+pyparsing==3.0.9 \
+    --hash=sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb \
+    --hash=sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc
     # via packaging
-pytest==7.2.0
-    # via -r /var/folders/5z/zrfn8mrs2yj5cckpwyry7btm0000gn/T/tmpjh9hcten
-tomli==2.0.1
+pytest==7.2.0 \
+    --hash=sha256:892f933d339f068883b6fd5a459f03d85bfcb355e4981e146d2c7616c21fef71 \
+    --hash=sha256:c4014eb40e10f11f355ad4e3c2fb2c6c6d1919c73f3b5a433de4708202cade59
+    # via -r /Users/masen/code/tox-dev/tox-pin-deps/examples/env-pins/.tox-pin-deps-py310-requirements.p587t3zp.in
+tomli==2.0.1 \
+    --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc \
+    --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f
     # via
     #   mypy
     #   pytest
-typing-extensions==4.4.0
+typing-extensions==4.4.0 \
+    --hash=sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa \
+    --hash=sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e
     # via mypy

--- a/examples/env-pins/requirements/py39.txt
+++ b/examples/env-pins/requirements/py39.txt
@@ -4,27 +4,77 @@
 #
 #    tox -e py39 --recreate --pip-compile
 #
-attrs==22.1.0
+attrs==22.1.0 \
+    --hash=sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6 \
+    --hash=sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c
     # via pytest
-exceptiongroup==1.0.4
+exceptiongroup==1.0.4 \
+    --hash=sha256:542adf9dea4055530d6e1279602fa5cb11dab2395fa650b8674eaec35fc4a828 \
+    --hash=sha256:bd14967b79cd9bdb54d97323216f8fdf533e278df937aa2a90089e7d6e06e5ec
     # via pytest
-iniconfig==1.1.1
+iniconfig==1.1.1 \
+    --hash=sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3 \
+    --hash=sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32
     # via pytest
-mypy==0.991
-    # via -r /var/folders/5z/zrfn8mrs2yj5cckpwyry7btm0000gn/T/tmpshdbug74
-mypy-extensions==0.4.3
+mypy==0.991 \
+    --hash=sha256:0714258640194d75677e86c786e80ccf294972cc76885d3ebbb560f11db0003d \
+    --hash=sha256:0c8f3be99e8a8bd403caa8c03be619544bc2c77a7093685dcf308c6b109426c6 \
+    --hash=sha256:0cca5adf694af539aeaa6ac633a7afe9bbd760df9d31be55ab780b77ab5ae8bf \
+    --hash=sha256:1c8cd4fb70e8584ca1ed5805cbc7c017a3d1a29fb450621089ffed3e99d1857f \
+    --hash=sha256:1f7d1a520373e2272b10796c3ff721ea1a0712288cafaa95931e66aa15798813 \
+    --hash=sha256:209ee89fbb0deed518605edddd234af80506aec932ad28d73c08f1400ef80a33 \
+    --hash=sha256:26efb2fcc6b67e4d5a55561f39176821d2adf88f2745ddc72751b7890f3194ad \
+    --hash=sha256:37bd02ebf9d10e05b00d71302d2c2e6ca333e6c2a8584a98c00e038db8121f05 \
+    --hash=sha256:3a700330b567114b673cf8ee7388e949f843b356a73b5ab22dd7cff4742a5297 \
+    --hash=sha256:3c0165ba8f354a6d9881809ef29f1a9318a236a6d81c690094c5df32107bde06 \
+    --hash=sha256:3d80e36b7d7a9259b740be6d8d906221789b0d836201af4234093cae89ced0cd \
+    --hash=sha256:4175593dc25d9da12f7de8de873a33f9b2b8bdb4e827a7cae952e5b1a342e243 \
+    --hash=sha256:4307270436fd7694b41f913eb09210faff27ea4979ecbcd849e57d2da2f65305 \
+    --hash=sha256:5e80e758243b97b618cdf22004beb09e8a2de1af481382e4d84bc52152d1c476 \
+    --hash=sha256:641411733b127c3e0dab94c45af15fea99e4468f99ac88b39efb1ad677da5711 \
+    --hash=sha256:652b651d42f155033a1967739788c436491b577b6a44e4c39fb340d0ee7f0d70 \
+    --hash=sha256:6d7464bac72a85cb3491c7e92b5b62f3dcccb8af26826257760a552a5e244aa5 \
+    --hash=sha256:74e259b5c19f70d35fcc1ad3d56499065c601dfe94ff67ae48b85596b9ec1461 \
+    --hash=sha256:7d17e0a9707d0772f4a7b878f04b4fd11f6f5bcb9b3813975a9b13c9332153ab \
+    --hash=sha256:901c2c269c616e6cb0998b33d4adbb4a6af0ac4ce5cd078afd7bc95830e62c1c \
+    --hash=sha256:98e781cd35c0acf33eb0295e8b9c55cdbef64fcb35f6d3aa2186f289bed6e80d \
+    --hash=sha256:a12c56bf73cdab116df96e4ff39610b92a348cc99a1307e1da3c3768bbb5b135 \
+    --hash=sha256:ac6e503823143464538efda0e8e356d871557ef60ccd38f8824a4257acc18d93 \
+    --hash=sha256:b8472f736a5bfb159a5e36740847808f6f5b659960115ff29c7cecec1741c648 \
+    --hash=sha256:b86ce2c1866a748c0f6faca5232059f881cda6dda2a893b9a8373353cfe3715a \
+    --hash=sha256:bc9ec663ed6c8f15f4ae9d3c04c989b744436c16d26580eaa760ae9dd5d662eb \
+    --hash=sha256:c9166b3f81a10cdf9b49f2d594b21b31adadb3d5e9db9b834866c3258b695be3 \
+    --hash=sha256:d13674f3fb73805ba0c45eb6c0c3053d218aa1f7abead6e446d474529aafc372 \
+    --hash=sha256:de32edc9b0a7e67c2775e574cb061a537660e51210fbf6006b0b36ea695ae9bb \
+    --hash=sha256:e62ebaad93be3ad1a828a11e90f0e76f15449371ffeecca4a0a0b9adc99abcef
+    # via -r /Users/masen/code/tox-dev/tox-pin-deps/examples/env-pins/.tox-pin-deps-py39-requirements.hfka17zj.in
+mypy-extensions==0.4.3 \
+    --hash=sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d \
+    --hash=sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8
     # via mypy
-packaging==21.3
+packaging==21.3 \
+    --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
+    --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
     # via pytest
-pluggy==1.0.0
+pluggy==1.0.0 \
+    --hash=sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159 \
+    --hash=sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3
     # via pytest
-pyparsing==3.0.9
+pyparsing==3.0.9 \
+    --hash=sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb \
+    --hash=sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc
     # via packaging
-pytest==7.2.0
-    # via -r /var/folders/5z/zrfn8mrs2yj5cckpwyry7btm0000gn/T/tmpshdbug74
-tomli==2.0.1
+pytest==7.2.0 \
+    --hash=sha256:892f933d339f068883b6fd5a459f03d85bfcb355e4981e146d2c7616c21fef71 \
+    --hash=sha256:c4014eb40e10f11f355ad4e3c2fb2c6c6d1919c73f3b5a433de4708202cade59
+    # via -r /Users/masen/code/tox-dev/tox-pin-deps/examples/env-pins/.tox-pin-deps-py39-requirements.hfka17zj.in
+tomli==2.0.1 \
+    --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc \
+    --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f
     # via
     #   mypy
     #   pytest
-typing-extensions==4.4.0
+typing-extensions==4.4.0 \
+    --hash=sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa \
+    --hash=sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e
     # via mypy

--- a/examples/env-pins/tox.ini
+++ b/examples/env-pins/tox.ini
@@ -3,6 +3,7 @@ skipsdist = true
 envlist = py27,py39,py310
 
 [testenv]
+pip_compile_opts = --generate-hashes -v
 deps =
     pytest
     mypy

--- a/src/tox_pin_deps/plugin.py
+++ b/src/tox_pin_deps/plugin.py
@@ -91,11 +91,8 @@ def tox_testenv_install_deps(venv, action):
             cwd=venv.path,
             action=action,
         )
-        opts = _opts(venv)
-        action.setactivity(
-            "pip-compile",
-            str(["--output-file", str(env_requirements)] + opts),
-        )
+        opts = ["--output-file", str(env_requirements), *_opts(venv)]
+        action.setactivity("pip-compile", str(opts))
         env_requirements.parent.mkdir(parents=True, exist_ok=True)
         with tempfile.NamedTemporaryFile(
             prefix=f".tox-pin-deps-{venv.envconfig.envname}-requirements.",
@@ -105,7 +102,7 @@ def tox_testenv_install_deps(venv, action):
             tf.write("\n".join(str(d) for d in deps).encode())
             tf.flush()
             venv._pcall(
-                ["pip-compile", tf.name, "--output-file", env_requirements] + opts,
+                ["pip-compile", tf.name] + opts,
                 cwd=venv.path,
                 action=action,
                 env={"CUSTOM_COMPILE_COMMAND": _custom_command(venv)},

--- a/src/tox_pin_deps/plugin.py
+++ b/src/tox_pin_deps/plugin.py
@@ -1,9 +1,12 @@
+import os
 from pathlib import Path
+import shlex
 import tempfile
 
 from tox import hookimpl
 from tox.config import DepConfig
 
+ENV_PIP_COMPILE_OPTS = "PIP_COMPILE_OPTS"
 CUSTOM_COMPILE_COMMAND = "tox -e {envname} --recreate --pip-compile"
 
 
@@ -32,6 +35,21 @@ def tox_addoption(parser):
         default=False,
         help="Do not replace deps with `requirements` files",
     )
+    parser.add_argument(
+        "--pip-compile-opts",
+        action="store",
+        default=None,
+        help=(
+            "Custom options passed to `pip-compile` when --pip-compile is used. "
+            "Also specify via environment variable PIP_COMPILE_OPTS."
+        ),
+    )
+    parser.add_testenv_attribute(
+        "pip_compile_opts",
+        type="string",
+        default=None,
+        help="Custom options passed to `pip-compile` when --pip-compile is used",
+    )
 
 
 def _deps(venv):
@@ -40,6 +58,23 @@ def _deps(venv):
     except AttributeError:  # pragma: no cover
         # _getresolvedeps was deprecated on tox 3.7.0 in favor of get_resolved_dependencies
         return venv._getresolvedeps()
+
+
+def _custom_command(venv):
+    cmd = CUSTOM_COMPILE_COMMAND.format(envname=venv.envconfig.envname)
+    pip_compile_opts_cli = venv.envconfig.config.option.pip_compile_opts
+    if pip_compile_opts_cli:
+        cmd += f" --pip-compile-opts {shlex.quote(pip_compile_opts_cli)}"
+    return cmd
+
+
+def _opts(venv):
+    sources = [
+        venv.envconfig.pip_compile_opts,
+        venv.envconfig.config.option.pip_compile_opts,
+        os.environ.get(ENV_PIP_COMPILE_OPTS),
+    ]
+    return [opt for source in sources for opt in shlex.split(source or "")]
 
 
 @hookimpl
@@ -56,7 +91,11 @@ def tox_testenv_install_deps(venv, action):
             cwd=venv.path,
             action=action,
         )
-        action.setactivity("pip-compile", "--output-file {}".format(env_requirements))
+        opts = _opts(venv)
+        action.setactivity(
+            "pip-compile",
+            str(["--output-file", str(env_requirements)] + opts),
+        )
         env_requirements.parent.mkdir(parents=True, exist_ok=True)
         with tempfile.NamedTemporaryFile(
             prefix=f".tox-pin-deps-{venv.envconfig.envname}-requirements.",
@@ -66,14 +105,10 @@ def tox_testenv_install_deps(venv, action):
             tf.write("\n".join(str(d) for d in deps).encode())
             tf.flush()
             venv._pcall(
-                ["pip-compile", tf.name, "--output-file", env_requirements],
+                ["pip-compile", tf.name, "--output-file", env_requirements] + opts,
                 cwd=venv.path,
                 action=action,
-                env={
-                    "CUSTOM_COMPILE_COMMAND": CUSTOM_COMPILE_COMMAND.format(
-                        envname=venv.envconfig.envname
-                    ),
-                },
+                env={"CUSTOM_COMPILE_COMMAND": _custom_command(venv)},
             )
     if env_requirements.exists():
         venv.envconfig.deps = [DepConfig(f"-r{env_requirements}")]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -13,6 +13,7 @@ def config(tmp_path):
     config = mock.Mock()
     config.toxinidir = tmp_path / "project_directory"
     config.toxinidir.mkdir()
+    config.option.pip_compile_opts = None
     return config
 
 
@@ -33,6 +34,7 @@ def envconfig(venv_name, config):
     envconfig = mock.Mock()
     envconfig.config = config
     envconfig.envname = venv_name
+    envconfig.pip_compile_opts = None
     return envconfig
 
 
@@ -80,3 +82,32 @@ def action():
 @pytest.fixture
 def parser():
     return mock.Mock()
+
+
+@pytest.fixture(
+    params=[None, "-v"], ids=["no_PIP_COMPILE_OPTS", "PIP_COMPILE_OPTS='-v'"]
+)
+def pip_compile_opts_env(request, monkeypatch):
+    if request.param:
+        monkeypatch.setenv("PIP_COMPILE_OPTS", request.param)
+    return request.param
+
+
+@pytest.fixture(
+    params=[None, "--quiet"],
+    ids=["no_--pip-compile-opts", "--pip-compile-opts='--quiet'"],
+)
+def pip_compile_opts_cli(request, venv):
+    if request.param:
+        venv.envconfig.config.option.pip_compile_opts = request.param
+    return request.param
+
+
+@pytest.fixture(
+    params=[None, "--generate-hashes -v"],
+    ids=["no_pip_compile_opts", "pip_compile_opts = --generate-hashes"],
+)
+def pip_compile_opts_testenv(request, venv):
+    if request.param:
+        venv.envconfig.pip_compile_opts = request.param
+    return request.param

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -1,3 +1,5 @@
+import shlex
+
 import tox_pin_deps.plugin
 
 
@@ -12,6 +14,9 @@ def test_tox_testenv_install_deps(
     action,
     ignore_pins,
     pip_compile,
+    pip_compile_opts_env,
+    pip_compile_opts_cli,
+    pip_compile_opts_testenv,
     deps,
     env_requirements,
 ):
@@ -35,6 +40,13 @@ def test_tox_testenv_install_deps(
             assert cmd[0] == "pip-compile"
             # not mocking tempfile at this time
             # assert cmd[1] == tf.name
-            assert cmd[2:] == ["--output-file", env_requirements]
+            exp_opts = []
+            if pip_compile_opts_testenv:
+                exp_opts.extend(shlex.split(pip_compile_opts_testenv))
+            if pip_compile_opts_cli:
+                exp_opts.extend(shlex.split(pip_compile_opts_cli))
+            if pip_compile_opts_env:
+                exp_opts.extend(shlex.split(pip_compile_opts_env))
+            assert cmd[2:] == ["--output-file", str(env_requirements)] + exp_opts
         else:
             venv._pcall.assert_not_called()


### PR DESCRIPTION
fixes #3 
reopen for new-signed history. replaces PR #9 