### PR TITLE
set `envconfig.deps` during `tox_configure`

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -14,6 +14,8 @@ def config(tmp_path):
     config.toxinidir = tmp_path / "project_directory"
     config.toxinidir.mkdir()
     config.option.pip_compile_opts = None
+    config.envconfigs = {}
+    config.envlist = []
     return config
 
 
@@ -35,6 +37,8 @@ def envconfig(venv_name, config):
     envconfig.config = config
     envconfig.envname = venv_name
     envconfig.pip_compile_opts = None
+    config.envconfigs[venv_name] = envconfig
+    config.envlist.append(venv_name)
     return envconfig
 
 


### PR DESCRIPTION
for each of the selected environments, update the `deps` with the lock file at configure time, if it exists

if the user passes `--pip-compile`, then don't update the `deps`, so that `tox_testenv_installdeps` can access them.

this has 3 very nice side effects:
  * `--pip-compile` now implies `--recreate`, because the compiled environment is created from the pin file, it won't match the unmodified `deps` passed when `--pip-compile` is present.
  * `--ignore-pins` now implies `--recreate`, for the same reason...and un-ignoring the pins will also recreate the environment.
  * normal runs now do NOT recreate the environment which it was doing _every_ time before

All around major win.

Replaces #10 