### PR TITLE
tox_configure: always `--recreate` with `--pip-compile`

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -39,6 +39,7 @@ def envconfig(venv_name, config):
     envconfig.config = config
     envconfig.envname = venv_name
     envconfig.pip_compile_opts = None
+    envconfig.recreate = False
     config.envconfigs[venv_name] = envconfig
     config.envlist.append(venv_name)
     return envconfig

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -55,6 +55,14 @@ def venv(envconfig):
 
 
 @pytest.fixture
+def dot_venv(config, envconfig, venv):
+    envconfig.envname = ".package"
+    config.envconfigs[envconfig.envname] = envconfig
+    config.envlist = [envconfig.envname]
+    return venv
+
+
+@pytest.fixture
 def mock_get_resolved_dependencies(venv):
     def get_resolved_dependencies():
         return venv.envconfig.deps

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -32,21 +32,17 @@ def test_tox_configure(
 
 
 def test_tox_configure_dot_envname(
-    venv,
+    dot_venv,
     config,
-    envconfig,
     action,
     deps_present,
     pip_compile,
 ):
-    envconfig.envname = ".package"
-    config.envconfigs[envconfig.envname] = envconfig
-    config.envlist = [envconfig.envname]
     assert tox_pin_deps.plugin.tox_configure(config) is None
-    venv.get_resolved_dependencies.assert_not_called()
-    venv._pcall.assert_not_called()
-    assert venv.envconfig.deps == deps_present
-    assert not venv.envconfig.recreate
+    dot_venv.get_resolved_dependencies.assert_not_called()
+    dot_venv._pcall.assert_not_called()
+    assert dot_venv.envconfig.deps == deps_present
+    assert not dot_venv.envconfig.recreate
 
 
 def test_tox_testenv_install_deps(
@@ -128,12 +124,11 @@ def test_tox_testenv_install_deps_will_install(
 
 
 def test_tox_testenv_install_deps_dot_envname(
-    venv,
+    dot_venv,
     action,
     deps_present,
 ):
-    venv.envconfig.envname = ".package"
-    assert tox_pin_deps.plugin.tox_testenv_install_deps(venv, action) is None
-    venv.get_resolved_dependencies.assert_not_called()
-    venv._pcall.assert_not_called()
-    assert venv.envconfig.deps == deps_present
+    assert tox_pin_deps.plugin.tox_testenv_install_deps(dot_venv, action) is None
+    dot_venv.get_resolved_dependencies.assert_not_called()
+    dot_venv._pcall.assert_not_called()
+    assert dot_venv.envconfig.deps == deps_present


### PR DESCRIPTION
smooth over the edge case where `--pip-compile` is given, but the current environment can be reused and so `tox_testenv_install_deps` and pip-compile wouldn't run

update test assesrtions to check for recreate condition

add test case for skipping recreate for dot testenvs, even when `--pip-compile` is given.