### PR TITLE
support `--pre` / `pip_pre` option

### DIFF
--- a/src/tox_pin_deps/compile.py
+++ b/src/tox_pin_deps/compile.py
@@ -81,6 +81,12 @@ class PipCompile(abc.ABC):
         """CLI options string from [testenv] pip_compile_opts key."""
         raise NotImplementedError
 
+    @property
+    @abc.abstractmethod
+    def env_pip_pre(self) -> bool:  # pragma: no cover
+        """[testenv] pip_pre value."""
+        raise NotImplementedError
+
     @abc.abstractmethod
     def execute(
         self,
@@ -164,6 +170,8 @@ class PipCompile(abc.ABC):
             run_id="tox-pin-deps",
         )
         cmd = ["pip-compile"]
+        if self.env_pip_pre:
+            cmd.append("--pre")
         opts = [str(s) for s in self.other_sources] + [
             "--output-file",
             str(self.env_requirements),

--- a/src/tox_pin_deps/plugin.py
+++ b/src/tox_pin_deps/plugin.py
@@ -48,6 +48,11 @@ class PipCompileTox3(PipCompile, ShimBase):
             return str(self.venv.envconfig.pip_compile_opts)
         return None
 
+    @property
+    def env_pip_pre(self) -> bool:
+        """[testenv] pip_pre value."""
+        return bool(self.venv.envconfig.pip_pre)
+
     def execute(
         self,
         cmd: t.Sequence[str],

--- a/src/tox_pin_deps/plugin4.py
+++ b/src/tox_pin_deps/plugin4.py
@@ -46,6 +46,11 @@ class PipCompileInstaller(PipCompile, Pip):
             return str(pip_compile_opts)
         return None
 
+    @property
+    def env_pip_pre(self) -> bool:
+        """[testenv] pip_pre value."""
+        return bool(self.venv.conf["pip_pre"])
+
     @staticmethod
     def _deps(pydeps: PythonDeps) -> t.Sequence[str]:
         return pydeps.lines()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -107,19 +107,6 @@ def mod_id():
 @pytest.fixture(
     scope="module",
     params=[
-        ("examples", "env-pins"),
-        ("examples", "pyproject-toml-pkg"),
-        ("examples", "setup-py-pkg"),
-    ],
-    ids=["examples/env-pins", "examples/pyproject-toml-pkg", "examples/setup-py-pkg"],
-)
-def _example_environment_root(request):
-    return Path(Path(__file__).resolve().parent.parent.parent, *request.param)
-
-
-@pytest.fixture(
-    scope="module",
-    params=[
         "examples/skipsdist",
         "examples/pyproj",
     ],

--- a/tests/integration/examples/pyproj/exp_lock_3.txt
+++ b/tests/integration/examples/pyproj/exp_lock_3.txt
@@ -1,0 +1,30 @@
+~renodeps installdeps: -r/.*/pyproj/requirements/nodeps\.txt
+nodeps inst:
+nodeps installed:
+nodeps run-test: commands[0] | pip freeze
+mock-pkg-bar==1.5
+mock-pkg-foo==0.1.0
+mock-pkg-quuc==2.2
+pyproj @
+~reprefoo installdeps: -r/.*/pyproj/requirements/prefoo\.txt
+prefoo inst:
+prefoo installed:
+prefoo run-test: commands[0] | pip freeze
+mock-pkg-bar==1.5
+mock-pkg-foo==1.0b2
+mock-pkg-quuc==2.2
+pyproj @
+~reoldfoo installdeps: -r/.*/pyproj/requirements/oldfoo\.txt
+oldfoo inst:
+oldfoo installed:
+oldfoo run-test: commands[0] | pip freeze
+mock-pkg-bar==1.5
+mock-pkg-foo==0.0.1
+mock-pkg-quuc==2.2
+pyproj @
+~reskipinst installdeps: -r/.*/pyproj/requirements/skipinst.txt
+skipinst installed:
+skipinst run-test: commands[0] | pip freeze
+mock-pkg-bar==0.1.1
+mock-pkg-foo==0.1.0
+mock-pkg-quuc==2.0

--- a/tests/integration/examples/pyproj/exp_lock_4.txt
+++ b/tests/integration/examples/pyproj/exp_lock_4.txt
@@ -1,0 +1,32 @@
+~renodeps: install_deps> python -I -m pip install -r /.*/pyproj/requirements/nodeps\.txt
+nodeps: install_package_deps> python -I -m pip install mock_pkg_quuc
+nodeps: install_package>
+nodeps: commands[0]> pip freeze
+mock-pkg-bar==1.5
+mock-pkg-foo==0.1.0
+mock-pkg-quuc==2.2
+pyproj @
+nodeps: OK
+~reprefoo: install_deps> python -I -m pip install --pre -r /.*/pyproj/requirements/prefoo\.txt --pre
+prefoo: install_package_deps> python -I -m pip install --pre mock_pkg_quuc --pre
+prefoo: install_package>
+prefoo: commands[0]> pip freeze
+mock-pkg-bar==1.5
+mock-pkg-foo==1.0b2
+mock-pkg-quuc==2.2
+pyproj @
+prefoo: OK
+~reoldfoo: install_deps> python -I -m pip install -r /.*/pyproj/requirements/oldfoo\.txt
+oldfoo: install_package_deps> python -I -m pip install mock_pkg_quuc
+oldfoo: install_package>
+oldfoo: commands[0]> pip freeze
+mock-pkg-bar==1.5
+mock-pkg-foo==0.0.1
+mock-pkg-quuc==2.2
+pyproj @
+oldfoo: OK
+~reskipinst: install_deps> python -I -m pip install -r /.*/pyproj/requirements/skipinst\.txt
+skipinst: commands[0]> pip freeze
+mock-pkg-bar==0.1.1
+mock-pkg-foo==0.1.0
+mock-pkg-quuc==2.0

--- a/tests/integration/examples/pyproj/exp_no_lock_3.txt
+++ b/tests/integration/examples/pyproj/exp_no_lock_3.txt
@@ -1,0 +1,28 @@
+nodeps inst:
+nodeps installed: mock-pkg-bar==1.5,mock-pkg-foo==0.1.0,mock-pkg-quuc==2.2,pyproj @
+nodeps run-test: commands[0] | pip freeze
+mock-pkg-bar==1.5
+mock-pkg-foo==0.1.0
+mock-pkg-quuc==2.2
+pyproj @
+prefoo inst:
+prefoo installed: mock-pkg-bar==1.5,mock-pkg-foo==1.0b2,mock-pkg-quuc==2.2,pyproj @
+prefoo run-test: commands[0] | pip freeze
+mock-pkg-bar==1.5
+mock-pkg-foo==1.0b2
+mock-pkg-quuc==2.2
+pyproj @
+oldfoo installdeps: mock_pkg_foo < 0.1
+oldfoo inst:
+oldfoo installed: mock-pkg-bar==1.5,mock-pkg-foo==0.0.1,mock-pkg-quuc==2.2,pyproj @
+oldfoo run-test: commands[0] | pip freeze
+mock-pkg-bar==1.5
+mock-pkg-foo==0.0.1
+mock-pkg-quuc==2.2
+pyproj @
+skipinst installdeps: mock_pkg_quuc < 2.1, mock_pkg_bar < 1.1
+skipinst installed: mock-pkg-bar==0.1.1,mock-pkg-foo==0.1.0,mock-pkg-quuc==2.0
+skipinst run-test: commands[0] | pip freeze
+mock-pkg-bar==0.1.1
+mock-pkg-foo==0.1.0
+mock-pkg-quuc==2.0

--- a/tests/integration/examples/pyproj/exp_no_lock_4.txt
+++ b/tests/integration/examples/pyproj/exp_no_lock_4.txt
@@ -1,0 +1,30 @@
+nodeps: install_package_deps> python -I -m pip install mock_pkg_quuc
+nodeps: install_package>
+nodeps: commands[0]> pip freeze
+mock-pkg-bar==1.5
+mock-pkg-foo==0.1.0
+mock-pkg-quuc==2.2
+pyproj @
+nodeps: OK
+prefoo: install_package_deps> python -I -m pip install --pre mock_pkg_quuc --pre
+prefoo: install_package>
+prefoo: commands[0]> pip freeze
+mock-pkg-bar==1.5
+mock-pkg-foo==1.0b2
+mock-pkg-quuc==2.2
+pyproj @
+prefoo: OK
+oldfoo: install_deps> python -I -m pip install 'mock_pkg_foo<0.1'
+oldfoo: install_package_deps> python -I -m pip install mock_pkg_quuc
+oldfoo: install_package>
+oldfoo: commands[0]> pip freeze
+mock-pkg-bar==1.5
+mock-pkg-foo==0.0.1
+mock-pkg-quuc==2.2
+pyproj @
+oldfoo: OK
+skipinst: install_deps> python -I -m pip install 'mock_pkg_bar<1.1' 'mock_pkg_quuc<2.1'
+skipinst: commands[0]> pip freeze
+mock-pkg-bar==0.1.1
+mock-pkg-foo==0.1.0
+mock-pkg-quuc==2.0

--- a/tests/integration/examples/pyproj/exp_pip_compile_3.txt
+++ b/tests/integration/examples/pyproj/exp_pip_compile_3.txt
@@ -1,0 +1,42 @@
+nodeps tox-pin-deps: ['pip', 'install', 'pip-tools']
+~renodeps tox-pin-deps: \['pip-compile', '/.*/pyproj/pyproject.toml', '--output-file', '/.*/pyproj/requirements/nodeps\.txt', '--generate-hashes', '-v', '--resolver=backtracking', '--extra-index-url'
+~renodeps installdeps: -r/.*/pyproj/requirements/nodeps\.txt
+nodeps inst:
+nodeps installed:
+nodeps run-test: commands[0] | pip freeze
+mock-pkg-bar==1.5
+mock-pkg-foo==0.1.0
+mock-pkg-quuc==2.2
+pip-tools==
+pyproj @
+prefoo tox-pin-deps: ['pip', 'install', 'pip-tools']
+~reprefoo tox-pin-deps: \['pip-compile', '--pre', '/.*/pyproj/pyproject\.toml', '--output-file', '/.*/pyproj/requirements/prefoo\.txt', '--resolver=backtracking', '--extra-index-url'
+~reprefoo installdeps: -r/.*/pyproj/requirements/prefoo\.txt
+prefoo inst:
+prefoo installed:
+prefoo run-test: commands[0] | pip freeze
+mock-pkg-bar==1.5
+mock-pkg-foo==1.0b2
+mock-pkg-quuc==2.2
+pip-tools==
+pyproj @
+oldfoo tox-pin-deps: ['pip', 'install', 'pip-tools']
+~reoldfoo tox-pin-deps: \['pip-compile', '/.*/pyproj/\.tox-pin-deps-oldfoo-requirements\..*\.in', '/.*/pyproj/pyproject\.toml', '--output-file', '/.*/pyproj/requirements/oldfoo\.txt', '--generate-hashes', '-v', '--extra-index-url'
+~reoldfoo installdeps: -r/.*/pyproj/requirements/oldfoo\.txt
+oldfoo inst:
+oldfoo installed:
+oldfoo run-test: commands[0] | pip freeze
+mock-pkg-bar==1.5
+mock-pkg-foo==0.0.1
+mock-pkg-quuc==2.2
+pip-tools==
+pyproj @
+skipinst tox-pin-deps: ['pip', 'install', 'pip-tools']
+~reskipinst tox-pin-deps: \['pip-compile', '/.*/pyproj/\.tox-pin-deps-skipinst-requirements\..*\.in', '--output-file', '/.*/pyproj/requirements/skipinst\.txt', '--generate-hashes', '-v', '--extra-index-url'
+~reskipinst installdeps: -r/.*/pyproj/requirements/skipinst\.txt
+skipinst installed:
+skipinst run-test: commands[0] | pip freeze
+mock-pkg-bar==0.1.1
+mock-pkg-foo==0.1.0
+mock-pkg-quuc==2.0
+pip-tools==

--- a/tests/integration/examples/pyproj/exp_pip_compile_4.txt
+++ b/tests/integration/examples/pyproj/exp_pip_compile_4.txt
@@ -1,0 +1,44 @@
+nodeps: tox-pin-deps> pip install pip-tools
+~renodeps: tox-pin-deps> pip-compile /.*/pyproj/pyproject\.toml --output-file /.*/pyproj/requirements/nodeps\.txt --generate-hashes -v --resolver=backtracking --extra-index-url
+~renodeps: install_deps> python -I -m pip install -r /.*/pyproj/requirements/nodeps\.txt
+nodeps: install_package_deps> python -I -m pip install mock_pkg_quuc
+nodeps: install_package>
+nodeps: commands[0]> pip freeze
+mock-pkg-bar==1.5
+mock-pkg-foo==0.1.0
+mock-pkg-quuc==2.2
+pip-tools==
+pyproj @
+nodeps: OK
+prefoo: tox-pin-deps> pip install pip-tools
+~reprefoo: tox-pin-deps> pip-compile --pre /.*/pyproj/pyproject\.toml --output-file /.*/pyproj/requirements/prefoo\.txt --resolver=backtracking --extra-index-url
+~reprefoo: install_deps> python -I -m pip install --pre -r /.*/pyproj/requirements/prefoo\.txt --pre
+prefoo: install_package_deps> python -I -m pip install --pre mock_pkg_quuc --pre
+prefoo: install_package>
+prefoo: commands[0]> pip freeze
+mock-pkg-bar==1.5
+mock-pkg-foo==1.0b2
+mock-pkg-quuc==2.2
+pip-tools==
+pyproj @
+prefoo: OK
+oldfoo: tox-pin-deps> pip install pip-tools
+~reoldfoo: tox-pin-deps> pip-compile /.*/pyproj/.tox-pin-deps-oldfoo-requirements\..*\.in /.*/pyproj/pyproject\.toml --output-file /.*/pyproj/requirements/oldfoo\.txt --generate-hashes -v --extra-index-url
+~reoldfoo: install_deps> python -I -m pip install -r /.*/pyproj/requirements/oldfoo\.txt
+oldfoo: install_package_deps> python -I -m pip install mock_pkg_quuc
+oldfoo: install_package>
+oldfoo: commands[0]> pip freeze
+mock-pkg-bar==1.5
+mock-pkg-foo==0.0.1
+mock-pkg-quuc==2.2
+pip-tools==
+pyproj @
+oldfoo: OK
+skipinst: tox-pin-deps> pip install pip-tools
+~reskipinst: tox-pin-deps> pip-compile /.*/pyproj/.tox-pin-deps-skipinst-requirements\..*\.in --output-file /.*/pyproj/requirements/skipinst\.txt --generate-hashes -v --extra-index-url
+~reskipinst: install_deps> python -I -m pip install -r /.*/pyproj/requirements/skipinst\.txt
+skipinst: commands[0]> pip freeze
+mock-pkg-bar==0.1.1
+mock-pkg-foo==0.1.0
+mock-pkg-quuc==2.0
+pip-tools==

--- a/tests/integration/examples/pyproj/exp_reuse_3.txt
+++ b/tests/integration/examples/pyproj/exp_reuse_3.txt
@@ -1,0 +1,26 @@
+nodeps inst-nodeps:
+nodeps installed: mock-pkg-bar==1.5,mock-pkg-foo==0.1.0,mock-pkg-quuc==2.2,pyproj @
+nodeps run-test: commands[0] | pip freeze
+mock-pkg-bar==1.5
+mock-pkg-foo==0.1.0
+mock-pkg-quuc==2.2
+pyproj @
+prefoo inst-nodeps:
+prefoo installed: mock-pkg-bar==1.5,mock-pkg-foo==1.0b2,mock-pkg-quuc==2.2,pyproj @
+prefoo run-test: commands[0] | pip freeze
+mock-pkg-bar==1.5
+mock-pkg-foo==1.0b2
+mock-pkg-quuc==2.2
+pyproj @
+oldfoo inst-nodeps:
+oldfoo installed: mock-pkg-bar==1.5,mock-pkg-foo==0.0.1,mock-pkg-quuc==2.2,pyproj @
+oldfoo run-test: commands[0] | pip freeze
+mock-pkg-bar==1.5
+mock-pkg-foo==0.0.1
+mock-pkg-quuc==2.2
+pyproj @
+skipinst installed: mock-pkg-bar==0.1.1,mock-pkg-foo==0.1.0,mock-pkg-quuc==2.0
+skipinst run-test: commands[0] | pip freeze
+mock-pkg-bar==0.1.1
+mock-pkg-foo==0.1.0
+mock-pkg-quuc==2.0

--- a/tests/integration/examples/pyproj/exp_reuse_4.txt
+++ b/tests/integration/examples/pyproj/exp_reuse_4.txt
@@ -1,0 +1,25 @@
+nodeps: install_package>
+nodeps: commands[0]> pip freeze
+mock-pkg-bar==1.5
+mock-pkg-foo==0.1.0
+mock-pkg-quuc==2.2
+pyproj @
+nodeps: OK
+prefoo: install_package>
+prefoo: commands[0]> pip freeze
+mock-pkg-bar==1.5
+mock-pkg-foo==1.0b2
+mock-pkg-quuc==2.2
+pyproj @
+prefoo: OK
+oldfoo: install_package>
+oldfoo: commands[0]> pip freeze
+mock-pkg-bar==1.5
+mock-pkg-foo==0.0.1
+mock-pkg-quuc==2.2
+pyproj @
+oldfoo: OK
+skipinst: commands[0]> pip freeze
+mock-pkg-bar==0.1.1
+mock-pkg-foo==0.1.0
+mock-pkg-quuc==2.0

--- a/tests/integration/examples/pyproj/tox.ini
+++ b/tests/integration/examples/pyproj/tox.ini
@@ -1,8 +1,6 @@
 [tox]
 isolated_build = true
-#envlist = nodeps, oldfoo, skipinst
-# XXX: nodeps env does not find/pin transitives, this is a bug
-envlist = oldfoo, skipinst
+envlist = nodeps, prefoo, oldfoo, skipinst
 
 
 [testenv]
@@ -10,6 +8,11 @@ pip_compile_opts = --generate-hashes -v
 commands = pip freeze
 
 [testenv:nodeps]
+pip_compile_opts = {[testenv]pip_compile_opts} --resolver=backtracking
+
+[testenv:prefoo]
+pip_compile_opts = --resolver=backtracking
+pip_pre = True
 
 [testenv:oldfoo]
 deps =

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -116,6 +116,11 @@ def skip_install(request):
     return request.param
 
 
+@pytest.fixture(params=[True, False], ids=["pip_pre", "no_pip_pre"])
+def pip_pre(request):
+    return request.param
+
+
 @pytest.fixture(params=[True, False], ids=["setup.py", "no_setup.py"])
 def setup_py(request, toxinidir):
     if request.param:

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ deps =
   flake8 ~= 5.0.4
   mypy > 0.990, < 0.999
   # tox3 is not py.typed
-  tox >= 4.0.0b2
+  tox >= 4.0.0
 commands =
   black --check setup.py src/ tests/
   flake8 setup.py src/ tests/


### PR DESCRIPTION
* plumb env config "pip_pre" to pip-compile invocation
* update unit tests
* add `pip_pre` environment to integration test `pyproj`
  * add validation for `pyproj` output
  * fix `nodeps` environment via `--resolver=backtracking`