### PR TITLE
tox.ini: [coverage:paths] mapping

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,8 @@ jobs:
         COVERALLS_PARALLEL: true
   coveralls:
     name: Indicate completion to coveralls.io
-    needs: integration
+    if: ${{ always() }}
+    needs: [unit, integration]
     runs-on: ubuntu-latest
     container: python:3-slim
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       run: coveralls --service=github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        COVERALLS_FLAG_NAME: ${{ matrix.test-name }}-unit
+        COVERALLS_FLAG_NAME: unit-${{ matrix.python-version }}
         COVERALLS_PARALLEL: true
   integration:
     needs: unit
@@ -54,7 +54,7 @@ jobs:
       run: coveralls --service=github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        COVERALLS_FLAG_NAME: ${{ matrix.test-name }}-interation
+        COVERALLS_FLAG_NAME: integration-${{ matrix.python-version }}
         COVERALLS_PARALLEL: true
   coveralls:
     name: Indicate completion to coveralls.io

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
   - pull_request
 
 jobs:
-  build:
+  unit:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -22,16 +22,43 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install tox tox-gh-actions coveralls
     - name: Test with tox
-      run: tox
+      run: tox -- tests/unit --cov tox_pin_deps
     - name: Upload coverage data
+      if: always()
       run: coveralls --service=github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        COVERALLS_FLAG_NAME: ${{ matrix.test-name }}
+        COVERALLS_FLAG_NAME: ${{ matrix.test-name }}-unit
+        COVERALLS_PARALLEL: true
+  integration:
+    needs: unit
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install tox tox-gh-actions coveralls
+    - name: Test with tox
+      run: tox -- tests/integration --cov tox_pin_deps
+    - name: Upload coverage data
+      if: always()
+      run: coveralls --service=github
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COVERALLS_FLAG_NAME: ${{ matrix.test-name }}-interation
         COVERALLS_PARALLEL: true
   coveralls:
     name: Indicate completion to coveralls.io
-    needs: build
+    needs: integration
     runs-on: ubuntu-latest
     container: python:3-slim
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -65,7 +65,6 @@ branch = True
 parallel = True
 
 [coverage:report]
-fail_under = 100
 show_missing = True
 
 [coverage:paths]

--- a/tox.ini
+++ b/tox.ini
@@ -67,3 +67,9 @@ parallel = True
 [coverage:report]
 fail_under = 100
 show_missing = True
+
+[coverage:paths]
+# this maps paths in the `.tox` directory to the top level when combining
+source =
+    src/tox_pin_deps
+    .tox/*/lib/python*/site-packages/tox_pin_deps


### PR DESCRIPTION
all virtualenvs need to report coverage over the same set of paths so that coveralls can render a line preview