### PR TITLE
plugin4: skip install_package_deps

### DIFF
--- a/src/tox_pin_deps/plugin4.py
+++ b/src/tox_pin_deps/plugin4.py
@@ -105,8 +105,11 @@ class PipCompileInstaller(PipCompile, Pip):
                 self._installed_from_lock_file = True
         if self._installed_from_lock_file and of_type == "package":
             # do not override pinned deps with package requirements
-            for item in arguments:
-                item.deps[:] = []
+            try:
+                for item in arguments:
+                    item.deps[:] = []
+            except TypeError:
+                pass  # maybe given something other than a list of packages?
         super().install(
             arguments=pinned_deps or arguments,
             section=section,

--- a/src/tox_pin_deps/plugin4.py
+++ b/src/tox_pin_deps/plugin4.py
@@ -7,6 +7,7 @@ from tox.config.cli.parser import DEFAULT_VERBOSITY, ToxParser
 from tox.execute.request import StdinSource
 from tox.plugin import impl
 from tox.tox_env.api import ToxEnvCreateArgs
+from tox.tox_env.python.api import Python
 from tox.tox_env.python.pip.pip_install import Pip
 from tox.tox_env.python.pip.req_file import PythonDeps
 from tox.tox_env.python.virtual_env.runner import VirtualEnvRunner
@@ -19,9 +20,9 @@ from .compile import PipCompile
 class PipCompileInstaller(PipCompile, Pip):
     """tox4 Installer that uses `pip-compile` or env-specific lock files."""
 
-    def __init__(self, *args, **kwargs):  # type: ignore
+    def __init__(self, tox_env: Python, with_list_deps: bool = True):
         self._installed_from_lock_file = False
-        super().__init__(*args, **kwargs)
+        super().__init__(tox_env, with_list_deps)
 
     @property
     def toxinidir(self) -> Path:

--- a/tests/integration/examples/pyproj/exp_lock_4.txt
+++ b/tests/integration/examples/pyproj/exp_lock_4.txt
@@ -1,5 +1,4 @@
 ~renodeps: install_deps> python -I -m pip install -r /.*/pyproj/requirements/nodeps\.txt
-nodeps: install_package_deps> python -I -m pip install mock_pkg_quuc
 nodeps: install_package>
 nodeps: commands[0]> pip freeze
 mock-pkg-bar==1.5
@@ -8,7 +7,6 @@ mock-pkg-quuc==2.2
 pyproj @
 nodeps: OK
 ~reprefoo: install_deps> python -I -m pip install --pre -r /.*/pyproj/requirements/prefoo\.txt --pre
-prefoo: install_package_deps> python -I -m pip install --pre mock_pkg_quuc --pre
 prefoo: install_package>
 prefoo: commands[0]> pip freeze
 mock-pkg-bar==1.5
@@ -17,7 +15,6 @@ mock-pkg-quuc==2.2
 pyproj @
 prefoo: OK
 ~reoldfoo: install_deps> python -I -m pip install -r /.*/pyproj/requirements/oldfoo\.txt
-oldfoo: install_package_deps> python -I -m pip install mock_pkg_quuc
 oldfoo: install_package>
 oldfoo: commands[0]> pip freeze
 mock-pkg-bar==1.5

--- a/tests/integration/examples/pyproj/exp_pip_compile_4.txt
+++ b/tests/integration/examples/pyproj/exp_pip_compile_4.txt
@@ -1,7 +1,6 @@
 nodeps: tox-pin-deps> pip install pip-tools
 ~renodeps: tox-pin-deps> pip-compile /.*/pyproj/pyproject\.toml --output-file /.*/pyproj/requirements/nodeps\.txt --generate-hashes -v --resolver=backtracking --extra-index-url
 ~renodeps: install_deps> python -I -m pip install -r /.*/pyproj/requirements/nodeps\.txt
-nodeps: install_package_deps> python -I -m pip install mock_pkg_quuc
 nodeps: install_package>
 nodeps: commands[0]> pip freeze
 mock-pkg-bar==1.5
@@ -13,7 +12,6 @@ nodeps: OK
 prefoo: tox-pin-deps> pip install pip-tools
 ~reprefoo: tox-pin-deps> pip-compile --pre /.*/pyproj/pyproject\.toml --output-file /.*/pyproj/requirements/prefoo\.txt --resolver=backtracking --extra-index-url
 ~reprefoo: install_deps> python -I -m pip install --pre -r /.*/pyproj/requirements/prefoo\.txt --pre
-prefoo: install_package_deps> python -I -m pip install --pre mock_pkg_quuc --pre
 prefoo: install_package>
 prefoo: commands[0]> pip freeze
 mock-pkg-bar==1.5
@@ -25,7 +23,6 @@ prefoo: OK
 oldfoo: tox-pin-deps> pip install pip-tools
 ~reoldfoo: tox-pin-deps> pip-compile /.*/pyproj/.tox-pin-deps-oldfoo-requirements\..*\.in /.*/pyproj/pyproject\.toml --output-file /.*/pyproj/requirements/oldfoo\.txt --generate-hashes -v --extra-index-url
 ~reoldfoo: install_deps> python -I -m pip install -r /.*/pyproj/requirements/oldfoo\.txt
-oldfoo: install_package_deps> python -I -m pip install mock_pkg_quuc
 oldfoo: install_package>
 oldfoo: commands[0]> pip freeze
 mock-pkg-bar==1.5


### PR DESCRIPTION
If the installer already installed from a lock file do not also install the package deps

Fix #33 